### PR TITLE
fix command line option "--width"

### DIFF
--- a/ansitoimg/__init__.py
+++ b/ansitoimg/__init__.py
@@ -65,7 +65,7 @@ def cli():  # pragma: no cover
 
 	args = parser.parse_args()
 	ansi = args.input.read()
-	width = _resolveWidth(args.wide, args.width)
+	width = _resolveWidth(args.wide, int(args.width))
 
 	# Plugin
 	pluginMap = {

--- a/ansitoimg/utils.py
+++ b/ansitoimg/utils.py
@@ -9,6 +9,7 @@ TITLE = "AnsiToImg (courtesy of Rich)"
 
 
 def _resolveWidth(wide: bool, width: int = 49):
+	width = int(width)
 	if width == 49 and wide:
 		return 89
 	return width

--- a/ansitoimg/utils.py
+++ b/ansitoimg/utils.py
@@ -9,7 +9,6 @@ TITLE = "AnsiToImg (courtesy of Rich)"
 
 
 def _resolveWidth(wide: bool, width: int = 49):
-	width = int(width)
 	if width == 49 and wide:
 		return 89
 	return width


### PR DESCRIPTION
when specifying `--width`, i'm getting the following error:

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/opt/homebrew/lib/python3.11/site-packages/ansitoimg/__main__.py", line 6, in <module>
    cli()
  File "/opt/homebrew/lib/python3.11/site-packages/ansitoimg/__init__.py", line 79, in cli
    ansiToSVG(ansi, args.output, args.theme, width=width, title=args.title)
  File "/opt/homebrew/lib/python3.11/site-packages/ansitoimg/render.py", line 79, in ansiToSVG
    console = _doRichRender(ansiText, _resolveWidth(wide, width))
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/ansitoimg/render.py", line 23, in _doRichRender
    console.print(richText)
  File "/opt/homebrew/lib/python3.11/site-packages/rich/console.py", line 1694, in print
    extend(render(renderable, render_options))
  File "/opt/homebrew/lib/python3.11/site-packages/rich/console.py", line 1299, in render
    if _options.max_width < 1:
       ^^^^^^^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'str' and 'int'
```

This PR attempts to fix it.