### PR TITLE
Fix WIDTH_DEFAULT

### DIFF
--- a/ansitoimg/__init__.py
+++ b/ansitoimg/__init__.py
@@ -60,6 +60,7 @@ def cli() -> None:  # pragma: no cover
 	parser.add_argument(
 		"--width",
 		default=WIDTH_DEFAULT,
+		type=int,
 		help="Explicitly set the width in chars, use 'auto' to attempt to automatically "
 		"calculate this from your environment",
 	)
@@ -67,7 +68,7 @@ def cli() -> None:  # pragma: no cover
 	args = parser.parse_args()
 	ansi = args.input.read()
 
-	width = int(args.width) if args.width.isdigit() else WIDTH_DEFAULT
+	width = args.width 
 	if width == WIDTH_DEFAULT and args.wide:
 		width = WIDTH_WIDE
 

--- a/ansitoimg/__init__.py
+++ b/ansitoimg/__init__.py
@@ -68,7 +68,7 @@ def cli() -> None:  # pragma: no cover
 	args = parser.parse_args()
 	ansi = args.input.read()
 
-	width = args.width 
+	width = args.width
 	if width == WIDTH_DEFAULT and args.wide:
 		width = WIDTH_WIDE
 

--- a/ansitoimg/utils.py
+++ b/ansitoimg/utils.py
@@ -2,7 +2,7 @@
 TEXT_HEIGHT = 21
 TEXT_WIDTH = 12
 
-WIDTH_DEFAULT = 49
+WIDTH_DEFAULT = "49"
 WIDTH_WIDE = 89
 
 TITLE = "AnsiToImg (via Textualize/rich)"

--- a/ansitoimg/utils.py
+++ b/ansitoimg/utils.py
@@ -2,7 +2,7 @@
 TEXT_HEIGHT = 21
 TEXT_WIDTH = 12
 
-WIDTH_DEFAULT = "49"
+WIDTH_DEFAULT = 49
 WIDTH_WIDE = 89
 
 TITLE = "AnsiToImg (via Textualize/rich)"


### PR DESCRIPTION
Fix the bug: 
``` sh
ls --color=always /etc | ansitoimg ls.svg
Traceback (most recent call last):
  File "~/.local/bin/ansitoimg", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "~/.local/pipx/venvs/ansitoimg/lib64/python3.12/site-packages/ansitoimg/__init__.py", line 69, in cli
    width = int(args.width) if args.width.isdigit() else WIDTH_DEFAULT
```

<!--
Thank you for contributing to our project by submitting a Pull Request!
Before proceeding, please ensure you have read and followed our Pull Request
guidelines: https://github.com/FredHappyface/.github/blob/master/CONTRIBUTING.md

By submitting this Pull Request, you confirm that you have followed our
contributing guidelines and that the code
-->

### Purpose of This Pull Request

Please check the relevant option by placing an "X" inside the brackets:

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other (please explain):
